### PR TITLE
docs: fix README installation flow and clarify user vs developer scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,23 +68,41 @@ osm install gmail-reader
 ---
 
 
-## 👥 Who uses OSM
+## 👥 Scope: who uses OSM vs who develops OSM
 
-- **Agents as consumers**: use `osm list`, `osm search`, `osm install`, and `osm info` to discover and install skills from the registry.
-- **Users/agents as creators**: create skill repositories on GitHub, maintain `SKILL.md`, and publish metadata (`name`, `description`, `repository`, permissions, dependencies) to OSM.
-- **Local machine responsibility**: OSM stores skill source files + install metadata locally, so agents can execute skills directly after install.
+### 1) Skill users (agents + skill developers)
+- Use the **CLI only** to discover and install skills: `osm list`, `osm search`, `osm install`, `osm info`.
+- This is the right scope for:
+  - agents that need to run skills;
+  - developers that build skills and want to test them locally through OSM.
+
+### 2) OSM developers (CLI/backend/frontend maintainers)
+- Work on the OSM codebase itself (`packages/cli`, `packages/backend`, `packages/frontend`).
+- Run local services, contribute code, and maintain the platform.
+
+**Local machine responsibility**: OSM stores skill source files + install metadata locally, so agents can execute skills directly after install.
 
 ---
 ## 🚀 Quick Start
 
 ### Installation
 
+#### Option A — clone and install (recommended for OSM developers)
+
 ```bash
 # Clone and setup
-git clone https://github.com/yourusername/osm.git
+git clone https://github.com/giannisalvatore/osm.git
 cd osm
-./quickstart.sh
+./install.sh
 ```
+
+#### Option B — one-line install (recommended for skill users)
+
+```bash
+curl -fsSL https://www.osmagent.com/install.sh | bash
+```
+
+> Note: use `bash` (not `sh`) so the installer runs with the expected shell features.
 
 ### Start Services
 


### PR DESCRIPTION
### Motivation
- The installation section in `README.md` contained an incorrect clone URL and an ambiguous one-line installer, which hindered straightforward onboarding.  
- The project roles and scopes were mixed together, so users and platform developers needed clearer separation.

### Description
- Updated the clone-based install instructions to use the repository `https://github.com/giannisalvatore/osm.git` and run `./install.sh` for local setup.  
- Added a safe one-liner installer for skill users: `curl -fsSL https://www.osmagent.com/install.sh | bash` and an explicit note to use `bash`.  
- Reworked the documentation to separate scopes into `Skill users (agents + skill developers)` who only use the CLI and `OSM developers` who work on `packages/cli`, `packages/backend`, and `packages/frontend`.

### Testing
- Applied the documentation patch successfully using the repository patch tooling (`apply_patch`) and verified the file update succeeded.  
- Inspected the updated `README.md` content with file view commands to confirm the new installation steps and scope sections appear as intended.  
- Performed a repository status check to ensure no unexpected files were modified after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69945279b160832a92202596f74f35ee)